### PR TITLE
Correction of calculation of physical values

### DIFF
--- a/docs/specifications.rst
+++ b/docs/specifications.rst
@@ -228,14 +228,14 @@ Example 1.
         m = 0.0008
         b = physical_max / m - digital_max
         b = 3.3 / 0.0008 - 4095
-        b = 30.0
+        b = 0.5
         
     and with that the physical values (voltage)::
 
         physical_value = m * (digital_value + b)
-        physical_value = 0.0008 * (digital_value + 30.0)
+        physical_value = 0.0008 * (digital_value + 0.5)
 
-    A digital value of 2048 will represent 0.0008 * (2048 + 0) = 1.66
+    A digital value of 2048 will represent 0.0008 * (2048 + 0) = 1.65
     volts, as expected.
 
 Example 2.
@@ -258,6 +258,6 @@ Example 2.
         m = (physical_max - physical_min) / (digital_max - digital_min)
         m = (2.952 + 2.048) / (16383 - 0)
         m = 5 / 16383 = 0.00031
-        b = offset = physical_max / m - digital_max = -6860.41935483871
+        b = offset = physical_max / m - digital_max = -23093.4768
         y = m * x + b
-        physical_value = 0.00031 * (digital_value + -6860.41935483871)
+        physical_value = 0.00031 * (digital_value + -23093.4768)

--- a/docs/specifications.rst
+++ b/docs/specifications.rst
@@ -204,7 +204,7 @@ these the physical values can be obtained using  the line equation::
 
     b = offset = physical_max / m - digital_max
     y = m * (x + b)
-    physical_value = m * (digital_value) + b)
+    physical_value = m * (digital_value + b)
 
 Example 1.
     An EDF file contains data obtained after measuring voltage with the
@@ -226,13 +226,16 @@ Example 1.
         m = (physical_max - physical_min) / (digital_max - digital_min)
         m = (3.3 - 0) / (4095 - 0)
         m = 0.0008
-
+        b = physical_max / m - digital_max
+        b = 3.3 / 0.0008 - 4095
+        b = 30.0
+        
     and with that the physical values (voltage)::
 
-        physical_value = m * (digital_value + physical_min)
-        physical_value = 0.0008 * (digital_value + 0)
+        physical_value = m * (digital_value + b)
+        physical_value = 0.0008 * (digital_value + 30.0)
 
-    A digital value of 2048 will represent 0.0008 * (2048 + 0) = 1.65
+    A digital value of 2048 will represent 0.0008 * (2048 + 0) = 1.66
     volts, as expected.
 
 Example 2.

--- a/docs/specifications.rst
+++ b/docs/specifications.rst
@@ -187,7 +187,7 @@ by change in *x*::
 and if the slope *m* and the intercept *b* are known, then the line can
 be described by::
 
-    y = m * x + b
+    y = m * (x + b)
 
 It can be seen that the raw int16 data values stored in an EDF file
 correspond to *x* in that equation, that the physical values that we are
@@ -202,9 +202,9 @@ The slope can be calculated as::
 and the offset (or intercept) *b* will be the physical_min value. From
 these the physical values can be obtained using  the line equation::
 
-    b = offset = physical_min
-    y = m * x + b
-    physical_value = (m * digital_value) + b
+    b = offset = physical_max / m - digital_max
+    y = m * (x + b)
+    physical_value = m * (digital_value) + b)
 
 Example 1.
     An EDF file contains data obtained after measuring voltage with the
@@ -229,10 +229,10 @@ Example 1.
 
     and with that the physical values (voltage)::
 
-        physical_value = (m * digital_value) + physical_min
-        physical_value = (0.0008 * digital_value) + 0
+        physical_value = m * (digital_value + physical_min)
+        physical_value = 0.0008 * (digital_value + 0)
 
-    A digital value of 2048 will represent (0.0008 * 2048) + 0 = 1.65
+    A digital value of 2048 will represent 0.0008 * (2048 + 0) = 1.65
     volts, as expected.
 
 Example 2.
@@ -255,6 +255,6 @@ Example 2.
         m = (physical_max - physical_min) / (digital_max - digital_min)
         m = (2.952 + 2.048) / (16383 - 0)
         m = 5 / 16383 = 0.00031
-        b = offset = physical_min = -2.048
+        b = offset = physical_max / m - digital_max = -6860.41935483871
         y = m * x + b
-        physical_value = (0.00031 * digital_value) - 2.048
+        physical_value = 0.00031 * (digital_value + -6860.41935483871)


### PR DESCRIPTION
I used your code for some time in my project, but I think some of the calculations are wrong.

The slope formula should be

```Python
m = (physical_max - physical_min) / (digital_max - digital_min)
b =  physical_max / m - digital_max
physical_value = m * (digital_value + b)
```

I also think this is a bit counter-intuitive, but like this the following calculation is correct:

```Python
# example
digital_min = -32768
digital_max = 32767
physical_min = -200
physical_max = 200

# value=pmax means our physical_value should be exactly physical_max
digital_value = digital_max

# with the old calculation:
m = (physical_max - physical_min) / (digital_max - digital_min)
b = physical_min
physical_value_old = (digital_value  * m) + b
# physical_value_old =  -0.0030518043793392735

# new calculation
m = (physical_max - physical_min) / (digital_max - digital_min)
b = physical_max / m - digital_max
physical_value_new = m * (digital_value+ b)
# physical_value_new = 200.0
```

Your example still gets the same result with `physical_value ~= 1.65V`

This is also how it's done in [EDFLib](https://gitlab.com/Teuniz/EDFlib/-/blob/master/edflib.c#L987)

What do you think? 

( @antgon hope this reaches you, I see your account is not really active)